### PR TITLE
Adding Manual QA Details and Skills

### DIFF
--- a/components/Expectations.js
+++ b/components/Expectations.js
@@ -1,3 +1,4 @@
+import ALTERNATIVES from '../data/alternatives';
 import { ROLE_EXPECTATIONS } from '../data/expectations';
 import ROLES from '../data/roles';
 
@@ -7,6 +8,7 @@ const Expectations = (props) => {
     <>
       {expectations.inheritsBehaviorsFrom && <InheritedBehaviors inheritsBehaviorsFrom={expectations.inheritsBehaviorsFrom} skillKey={skillKey} />}
       {!expectations.inheritsBehaviorsFrom && <Behaviors behaviors={expectations.behaviors} />}
+      {expectations.alternatives && <AlternativeBehaviors alternatives={expectations.alternatives} />}
     </>
   );
 };
@@ -19,6 +21,24 @@ const InheritedBehaviors = (props) => {
       <p>Inherits from <strong>{ROLES[inheritsBehaviorsFrom].title}</strong>:</p>
       <Behaviors behaviors={inheritedExpectations.behaviors} />
     </div>
+  );
+};
+
+const AlternativeBehaviors = (props) => {
+  const { alternatives } = props;
+
+  return (
+    <>
+      {Object.keys(alternatives).map((alternativeKey) => {
+        const alternative = alternatives[alternativeKey];
+        return (
+          <div key={alternativeKey}>
+            <p>Alternative: <strong>{ALTERNATIVES[alternativeKey].name}</strong></p>
+            <Behaviors behaviors={alternative.behaviors} />
+          </div>
+        );
+      })}
+    </>
   );
 };
 

--- a/data/alternatives.js
+++ b/data/alternatives.js
@@ -1,0 +1,7 @@
+const ALTERNATIVES = {
+  MANUAL_TESTING: {
+    name: 'Manual Testing',
+  },
+};
+
+export default ALTERNATIVES;

--- a/data/expectations.js
+++ b/data/expectations.js
@@ -10,7 +10,10 @@ export const ROLE_EXPECTATIONS = {
       alternatives: {
         MANUAL_TESTING: {
           behaviors: [
-            'Something for manual testing Associate Engineer',
+            'Able to follow test cases and acceptance criteria when executing manual testing.',
+            'Support in the creation and maintenance of documentation (Test Cases, Process docs, Test Plans).',
+            'Troubleshoot defects and accurately pinpoint errors.',
+            'Understand basic web and mobile testing strategies for testing cross-browser and mobile apps.',
           ],
         },
       },
@@ -51,6 +54,16 @@ export const ROLE_EXPECTATIONS = {
         'Tests new code thoroughly, both locally, and in production once shipped.',
         'Develops new instances of existing architecture, or minor improvements to existing architecture.',
       ],
+      alternatives: {
+        MANUAL_TESTING: {
+          behaviors: [
+            'Perform exploratory, functional, regression, integration and end-to-end testing.',
+            'Able run automated tests and troubleshoot failures.',
+            'Able to test mobile apps against different versions and environments.',
+            'Able to test Web on multi-browsers while using DevTools proficiently to troubleshoot errors.',
+          ],
+        },
+      },
     },
     DELIVERY: {
       behaviors: [
@@ -91,6 +104,16 @@ export const ROLE_EXPECTATIONS = {
         'Can solve large-sized problems with well designed and architected solutions.',
         'Designs and implements testable solutions to problems. Consistently writes tests for new features and bug fixes. Adds tests for uncovered areas.',
       ],
+      alternatives: {
+        MANUAL_TESTING: {
+          behaviors: [
+            'Assist  in architecting manual test suites and frameworks.',
+            'Maintain and create new automation test cases.',
+            'Able to test multiple clients (Android/iOS/web) and platform implementations.',
+            'Assist in managing test suites, team boards, and process documentation',
+          ],
+        },
+      },
     },
     DELIVERY: {
       behaviors: [

--- a/data/expectations.js
+++ b/data/expectations.js
@@ -7,6 +7,13 @@ export const ROLE_EXPECTATIONS = {
         'Can solve small-sized problems, can understand and contribute to solving medium-sized problems.',
         'Demonstrates basic understanding of testing frameworks.',
       ],
+      alternatives: {
+        MANUAL_TESTING: {
+          behaviors: [
+            'Something for manual testing Associate Engineer',
+          ],
+        },
+      },
     },
     DELIVERY: {
       behaviors: [

--- a/md/RolesOverview.mdx
+++ b/md/RolesOverview.mdx
@@ -14,6 +14,10 @@ Roles begin with a shared **Engineer** track and then fork at later levels to th
 
 <RolesDiagram />
 
+## QA Engineers
+
+QA Engineers have similar roles and responsibilities as any other Engineer described in this framework, but QA Engineers who focus on **Manual Testing** have slightly different expectations in the **Technical Excellence** skill. QA Engineers focused on **Automation** are expected to have similar **Technical Excellence** skills as any other Engineer so there are no behavioral distinctions.
+
 ## Tiles and Progression
 Role titles are for you, your manager and the team to understand your expected responsibilities and to track your progress, but you are free to use anything sensible for your outward facing title (e.g. LinkedIn, resume, etc.).
 


### PR DESCRIPTION
See changes here: https://career-journeys-sggohijbar.now.sh

Based on discussion with Chris Rose, we need to make some adjustments to support QA Engineers who are focused on manual testing.

As a starting point, I introduced the concept of "alternatives". I'm open to a different name but the point of it is to allow us to display an alternative set of skills. The current behaviors for Technical Excellence don't really make sense for manual testers so we need a way to display alternatives for them.

Behaviors pulled from Chris' doc here: https://docs.google.com/document/d/1qXhnz6eL23mr6CQl-YXegxsgk4sPOh7XzfGhJeIzDPw/edit?usp=sharing