### PR TITLE
Add separate QA roles

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -11,6 +11,7 @@ const Layout = (props) => {
         <div className="top-nav-links">
           <Link href="/"><a className={router.pathname === '/' ? 'active' : ''}>Home</a></Link>
           <Link href="/roles"><a className={router.pathname === '/roles' ? 'active' : ''}>Roles</a></Link>
+          <Link href="/qa-roles"><a className={router.pathname === '/qa-roles' ? 'active' : ''}>QA Roles</a></Link>
           <Link href="/skills"><a className={router.pathname === '/skills' ? 'active' : ''}>Skills</a></Link>
         </div>
       </div>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -10,7 +10,7 @@ const Layout = (props) => {
       <div className="top-nav">
         <div className="top-nav-links">
           <Link href="/"><a className={router.pathname === '/' ? 'active' : ''}>Home</a></Link>
-          <Link href="/roles"><a className={router.pathname === '/roles' ? 'active' : ''}>Roles</a></Link>
+          <Link href="/roles"><a className={router.pathname === '/roles' ? 'active' : ''}>Engineer Roles</a></Link>
           <Link href="/qa-roles"><a className={router.pathname === '/qa-roles' ? 'active' : ''}>QA Roles</a></Link>
           <Link href="/skills"><a className={router.pathname === '/skills' ? 'active' : ''}>Skills</a></Link>
         </div>

--- a/components/QARolesDiagram.js
+++ b/components/QARolesDiagram.js
@@ -1,0 +1,20 @@
+import styles from './QARolesDiagram.styles';
+import QA_ROLES from '../data/qa-roles';
+
+const QARolesDiagram = () => (
+  <div className="root">
+    <div className="grid">
+      <div className="role associate-qa-engineer">{QA_ROLES.ASSOCIATE_QA_ENGINEER.title}</div>
+      <div className="role qa-engineer">{QA_ROLES.QA_ENGINEER.title}</div>
+      <div className="role senior-qa-engineer">{QA_ROLES.SENIOR_QA_ENGINEER.title}</div>
+      <div className="role qa-automation-engineer">{QA_ROLES.QA_AUTOMATION_ENGINEER.title}</div>
+      <div className="role senior-qa-automation-engineer">{QA_ROLES.SENIOR_QA_AUTOMATION_ENGINEER.title}</div>
+      <div className="role staff-qa-automation-engineer">{QA_ROLES.STAFF_QA_AUTOMATION_ENGINEER.title}</div>
+      <div className="role qa-manager">{QA_ROLES.QA_MANAGER.title}</div>
+      <div className="role qa-director">{QA_ROLES.QA_DIRECTOR.title}</div>
+    </div>
+    <style jsx>{styles}</style>
+  </div>
+);
+
+export default QARolesDiagram;

--- a/components/QARolesDiagram.styles.js
+++ b/components/QARolesDiagram.styles.js
@@ -47,6 +47,9 @@ const styles = css`
   }
 
   .role {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     text-align: center;
     padding: 1.6rem;
     margin: 0.8rem;

--- a/components/QARolesDiagram.styles.js
+++ b/components/QARolesDiagram.styles.js
@@ -1,0 +1,58 @@
+import css from 'styled-jsx/css';
+import THEME from '../lib/theme';
+
+const styles = css`
+  .root {
+    max-width: 50rem;
+    margin: auto;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+  }
+
+  .associate-qa-engineer, .qa-engineer {
+    grid-column: 3 / span 3;
+  }
+
+  .senior-qa-engineer {
+    grid-row: 3;
+    grid-column: 1 / span 3;
+  }
+
+  .qa-automation-engineer {
+    grid-row: 3;
+    grid-column: 5 / span 3;
+  }
+
+  .qa-manager {
+    grid-row: 4;
+    grid-column: 1 / span 3;
+  }
+
+  .senior-qa-automation-engineer {
+    grid-row: 4;
+    grid-column: 5 / span 3;
+  }
+
+  .qa-director {
+    grid-row: 5;
+    grid-column: 1 / span 3;
+  }
+
+  .staff-qa-automation-engineer {
+    grid-row: 5;
+    grid-column: 5 / span 3;
+  }
+
+  .role {
+    text-align: center;
+    padding: 1.6rem;
+    margin: 0.8rem;
+    background-color: ${THEME.colors.green};
+    color: #fff;
+  }
+`;
+
+export default styles;

--- a/components/Role.js
+++ b/components/Role.js
@@ -8,7 +8,6 @@ const Role = (props) => {
     <div className="root">
       <div id={role.key} className="hidden-anchor" />
       <h2>{role.title}</h2>
-      <p>{role.description}</p>
       {Object.keys(SKILLS).map(skillKey => (
         <RoleSkillExpectations key={skillKey} roleKey={role.key} skillKey={skillKey} />
       ))}

--- a/components/Role.js
+++ b/components/Role.js
@@ -1,18 +1,16 @@
 import styles from './Role.styles';
-import ROLES from '../data/roles';
 import SKILLS from '../data/skills';
 import RoleSkillExpectations from './RoleSkillExpectations';
 
 const Role = (props) => {
-  const { roleKey } = props; // eslint-disable-line react/prop-types
-  const role = ROLES[roleKey];
+  const { role } = props; // eslint-disable-line react/prop-types
   return (
     <div className="root">
-      <div id={roleKey} className="hidden-anchor" />
+      <div id={role.key} className="hidden-anchor" />
       <h2>{role.title}</h2>
       <p>{role.description}</p>
       {Object.keys(SKILLS).map(skillKey => (
-        <RoleSkillExpectations key={skillKey} roleKey={roleKey} skillKey={skillKey} />
+        <RoleSkillExpectations key={skillKey} roleKey={role.key} skillKey={skillKey} />
       ))}
       <style jsx>{styles}</style>
     </div>

--- a/components/Role.styles.js
+++ b/components/Role.styles.js
@@ -1,15 +1,8 @@
 import css from 'styled-jsx/css';
-import THEME from '../lib/theme';
 
 const styles = css`
   .root {
     position: relative;
-  }
-
-  .hidden-anchor {
-    visibility: hidden;
-    position: absolute;
-    top: ${THEME.anchorTopOffset};
   }
 `;
 

--- a/components/RoleList.js
+++ b/components/RoleList.js
@@ -1,12 +1,12 @@
-import ROLES from '../data/roles';
 import Role from './Role';
 
-const RoleList = () => (
-  <div>
-    {Object.keys(ROLES).map(roleKey => (
-      <Role key={roleKey} roleKey={roleKey} />
-    ))}
-  </div>
-);
+const RoleList = (props) => {
+  const { roles } = props;
+  return (
+    <div>
+      {roles.map(role => <Role key={role.key} role={role} />)}
+    </div>
+  );
+};
 
 export default RoleList;

--- a/components/RoleNavigation.js
+++ b/components/RoleNavigation.js
@@ -1,19 +1,17 @@
-import ROLES from '../data/roles';
 import styles from './RoleNavigation.styles';
 
-const RoleNavigation = () => (
-  <div>
-    {Object.keys(ROLES).map((roleKey) => {
-      const { title } = ROLES[roleKey];
-
-      return (
-        <div key={roleKey}>
-          <a href={`#${roleKey}`} className="role-link">{title}</a>
+const RoleNavigation = (props) => {
+  const { roles } = props;
+  return (
+    <div>
+      {roles.map(role => (
+        <div key={role.key}>
+          <a href={`#${role.key}`} className="role-link">{role.title}</a>
         </div>
-      );
-    })}
-    <style jsx>{styles}</style>
-  </div>
-);
+      ))}
+      <style jsx>{styles}</style>
+    </div>
+  );
+};
 
 export default RoleNavigation;

--- a/components/Skill.js
+++ b/components/Skill.js
@@ -1,19 +1,18 @@
-import ROLES from '../data/roles';
 import SKILLS from '../data/skills';
 import SkillRoleExpectations from './SkillRoleExpectations';
 
-const Role = (props) => {
-  const { skillKey } = props;
+const Skill = (props) => {
+  const { roles, skillKey } = props;
   const skill = SKILLS[skillKey];
   return (
     <div key={skillKey}>
       <h3>{skill.name}</h3>
       <p>{skill.description}</p>
-      {Object.keys(ROLES).map(roleKey => (
-        <SkillRoleExpectations key={roleKey} roleKey={roleKey} skillKey={skillKey} />
+      {roles.map(role => (
+        <SkillRoleExpectations key={role.key} role={role} skillKey={skillKey} />
       ))}
     </div>
   );
 };
 
-export default Role;
+export default Skill;

--- a/components/SkillList.js
+++ b/components/SkillList.js
@@ -1,12 +1,15 @@
 import SKILLS from '../data/skills';
 import Skill from './Skill';
 
-const Skills = () => (
-  <div>
-    {Object.keys(SKILLS).map(skillKey => (
-      <Skill key={skillKey} skillKey={skillKey} />
-    ))}
-  </div>
-);
+const Skills = (props) => {
+  const { roles } = props;
+  return (
+    <div>
+      {Object.keys(SKILLS).map(skillKey => (
+        <Skill key={skillKey} skillKey={skillKey} roles={roles} />
+      ))}
+    </div>
+  );
+};
 
 export default Skills;

--- a/components/SkillList.styles.js
+++ b/components/SkillList.styles.js
@@ -1,17 +1,8 @@
 import css from 'styled-jsx/css';
 import THEME from '../lib/theme';
 
-const styles = css.global`
-  html {
-    font-size: 10px; // for rems
-    font-family: Helvetica, sans-serif
-  }
-
-  body {
-    font-size: 16px;
-  }
-
-  .hidden-anchor-root {
+const styles = css`
+  .root {
     position: relative;
   }
 

--- a/components/SkillNavigation.js
+++ b/components/SkillNavigation.js
@@ -1,0 +1,15 @@
+import styles from './SkillNavigation.styles';
+
+const SkillNavigation = () => (
+  <div>
+    <div>
+      <a href="#engineers" className="role-link">Engineers</a>
+    </div>
+    <div>
+      <a href="#qa-engineers" className="role-link">QA Engineers</a>
+    </div>
+    <style jsx>{styles}</style>
+  </div>
+);
+
+export default SkillNavigation;

--- a/components/SkillNavigation.styles.js
+++ b/components/SkillNavigation.styles.js
@@ -1,0 +1,17 @@
+import css from 'styled-jsx/css';
+
+const styles = css`
+  a.role-link {
+    display: inline-block;
+    width: 100%;
+    padding: 0.8rem 0;
+    text-decoration: none;
+    color: #333;
+  }
+
+  a.role-link:hover {
+    color: #999;
+  }
+`;
+
+export default styles;

--- a/components/SkillRoleExpectations.js
+++ b/components/SkillRoleExpectations.js
@@ -6,6 +6,8 @@ import Expectations from './Expectations';
 const SkillRoleExpectations = (props) => {
   const { roleKey, skillKey } = props;
 
+  console.log('roleKey', roleKey);
+  console.log('skillKey', skillKey);
   const expectations = ROLE_EXPECTATIONS[roleKey][skillKey];
   if (!expectations) return null;
 

--- a/components/SkillRoleExpectations.js
+++ b/components/SkillRoleExpectations.js
@@ -1,17 +1,12 @@
 import styles from './SkillRoleExpectations.styles';
 import { ROLE_EXPECTATIONS } from '../data/expectations';
-import ROLES from '../data/roles';
 import Expectations from './Expectations';
 
 const SkillRoleExpectations = (props) => {
-  const { roleKey, skillKey } = props;
+  const { role, skillKey } = props;
 
-  console.log('roleKey', roleKey);
-  console.log('skillKey', skillKey);
-  const expectations = ROLE_EXPECTATIONS[roleKey][skillKey];
+  const expectations = ROLE_EXPECTATIONS[role.key][skillKey];
   if (!expectations) return null;
-
-  const role = ROLES[roleKey];
 
   return (
     <div className="root">

--- a/data/expectations.js
+++ b/data/expectations.js
@@ -1,3 +1,5 @@
+import QA_ROLE_EXPECTATIONS from './qa-expectations';
+
 export const ROLE_EXPECTATIONS = {
   ASSOCIATE_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
@@ -295,6 +297,7 @@ export const ROLE_EXPECTATIONS = {
       inheritsBehaviorsFrom: 'PRINCIPAL_ENGINEER',
     },
   },
+  ...QA_ROLE_EXPECTATIONS,
 };
 
 export const SKILL_EXPECTATIONS = {};

--- a/data/expectations.js
+++ b/data/expectations.js
@@ -102,7 +102,7 @@ export const ROLE_EXPECTATIONS = {
     },
     STRATEGIC_CLARITY: {
       behaviors: [
-        'Actively engages with broader team in discussions regarding Strategy and Principles. Helps teammates understand how their work connects to overall strategy,', 'purpose and design principles.',
+        'Actively engages with broader team in discussions regarding Strategy and Principles. Helps teammates understand how their work connects to overall strategy, purpose and design principles.',
         'Demonstrates the ability to translate between basic business requirements and technical requirements.',
       ],
     },

--- a/data/expectations.js
+++ b/data/expectations.js
@@ -89,7 +89,7 @@ export const ROLE_EXPECTATIONS = {
     },
     DELIVERY: {
       behaviors: [
-        'Has end-to-end responsibility on projects of increasing complexity and contributes to code shared across projects.',
+        'Has end-to-end responsibility on projects of increasing complexity and contributes across projects.',
         'Works with product and design teams to tease out requirements / details.',
       ],
     },

--- a/data/expectations.js
+++ b/data/expectations.js
@@ -59,7 +59,7 @@ export const ROLE_EXPECTATIONS = {
       behaviors: [
         'Communicates with the wider team appropriately, focusing on timeliness and good quality conversations.',
         'Puts team priorities over their own.',
-        'Works closely with QA to ensure work meets the acceptance criteria.',
+        'Works closely with peers to ensure work meets the acceptance criteria.',
         'Effectively listens to opposing points of view during team discussions and allows alternate ideas to influence perspective.',
 
       ],

--- a/data/qa-expectations.js
+++ b/data/qa-expectations.js
@@ -2,10 +2,10 @@ const QA_ROLE_EXPECTATIONS = {
   ASSOCIATE_QA_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Demonstrates broad knowledge of programming concepts.',
-        'Works effectively within established architectures, following current best practices.',
-        'Can solve small-sized problems, can understand and contribute to solving medium-sized problems.',
-        'Demonstrates basic understanding of testing frameworks.',
+        'Able to follow test cases and acceptance criteria when executing manual testing.',
+        'Support in the creation and maintenance of documentation (Test Cases, Process docs, Test Plans).',
+        'Troubleshoot defects and accurately pinpoint errors.',
+        'Understand basic web and mobile testing strategies for testing cross-browser and mobile apps.',
       ],
     },
     DELIVERY: {
@@ -24,10 +24,10 @@ const QA_ROLE_EXPECTATIONS = {
   QA_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Owns a small-to-medium feature from technical design through completion.',
-        'Can solve medium-sized problems, can understand and contribute to solving large-sized problems.',
-        'Tests new code thoroughly, both locally, and in production once shipped.',
-        'Develops new instances of existing architecture, or minor improvements to existing architecture.',
+        'Perform exploratory, functional, regression, integration and end-to-end testing.',
+        'Able run automated tests and troubleshoot failures.',
+        'Able to test mobile apps against different versions and environments.',
+        'Able to test Web on multi-browsers while using DevTools proficiently to troubleshoot errors.',
       ],
     },
     DELIVERY: {
@@ -46,9 +46,10 @@ const QA_ROLE_EXPECTATIONS = {
   SENIOR_QA_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Owns a service or large technology component.',
-        'Can solve large-sized problems with well designed and architected solutions.',
-        'Designs and implements testable solutions to problems. Consistently writes tests for new features and bug fixes. Adds tests for uncovered areas.',
+        'Assist  in architecting manual test suites and frameworks.',
+        'Maintain and create new automation test cases.',
+        'Able to test multiple clients (Android/iOS/web) and platform implementations.',
+        'Assist in managing test suites, team boards, and process documentation',
       ],
     },
     DELIVERY: {
@@ -67,10 +68,12 @@ const QA_ROLE_EXPECTATIONS = {
   QA_AUTOMATION_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Owns large-scale and impactful service or collection of services.',
-        'Mentors peers to avoid antipatterns.',
-        'Builds complex, reusable architectures that demonstrate best practices and enable engineers to work more effectively.',
-        'Actively educates their team on testing best practices. Builds systems so as to eliminate entire classes of programmer error.',
+        'Knowledge of automation frameworks',
+        'Basic understanding of SQL',
+        'Basic understanding of API testing tools',
+        'Basic understanding of browser development tools (Chrome DevTools)',
+        'Basic understanding of mobile debugging tools (Charles)',
+        'Basic understanding of black-box, gray-box and white-box testing',
       ],
     },
     DELIVERY: {
@@ -89,10 +92,12 @@ const QA_ROLE_EXPECTATIONS = {
   SENIOR_QA_AUTOMATION_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Designs and builds complex, flexible architectures that demonstrates best practices and prepares for future needs.',
-        'Demonstrates organization-level expertise in a particular area or go-to person for solving problems in their domain expertise for all of engineering.',
-        'Actively educates their team in their areas of knowledge.',
-        'Designs systems and applications for testability and quality.  Marshals resources to improve testability and quality of systems and applications that need it.',
+        'Knowledge of an OOP language (Swift,Java, C#, Objective-C, etc…)',
+        'Knowledge of a scripting language (python, javascript etc..)',
+        'Understanding of SQL',
+        'Understanding of API testing tools',
+        'Understanding of Automation Frameworks (selenium, cucumber etc…)',
+        'Understanding of Gherkin',
       ],
     },
     DELIVERY: {
@@ -111,10 +116,7 @@ const QA_ROLE_EXPECTATIONS = {
   STAFF_QA_AUTOMATION_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Helps solve larger technical and architectural problems with the team when they need support.',
-        'Demonstrates solid understanding of entire system, understands the architecture, is able to contribute across multiple technologies, and presents other technologies to leverage.',
-        'Works directly with other organizations to help solve technical problems.',
-        'Holds entire team including Staff, Principal and Architects to technical expectations and agreements.',
+        'Understanding of automation architecture',
       ],
     },
     DELIVERY: {

--- a/data/qa-expectations.js
+++ b/data/qa-expectations.js
@@ -1,0 +1,169 @@
+const QA_ROLE_EXPECTATIONS = {
+  ASSOCIATE_QA_ENGINEER: {
+    TECHNICAL_EXCELLENCE: {
+      behaviors: [
+        'Demonstrates broad knowledge of programming concepts.',
+        'Works effectively within established architectures, following current best practices.',
+        'Can solve small-sized problems, can understand and contribute to solving medium-sized problems.',
+        'Demonstrates basic understanding of testing frameworks.',
+      ],
+    },
+    DELIVERY: {
+      inheritsBehaviorsFrom: 'ASSOCIATE_ENGINEER',
+    },
+    COLLABORATION: {
+      inheritsBehaviorsFrom: 'ASSOCIATE_ENGINEER',
+    },
+    STRATEGIC_CLARITY: {
+      inheritsBehaviorsFrom: 'ASSOCIATE_ENGINEER',
+    },
+    LEADERSHIP: {
+      inheritsBehaviorsFrom: 'ASSOCIATE_ENGINEER',
+    },
+  },
+  QA_ENGINEER: {
+    TECHNICAL_EXCELLENCE: {
+      behaviors: [
+        'Owns a small-to-medium feature from technical design through completion.',
+        'Can solve medium-sized problems, can understand and contribute to solving large-sized problems.',
+        'Tests new code thoroughly, both locally, and in production once shipped.',
+        'Develops new instances of existing architecture, or minor improvements to existing architecture.',
+      ],
+    },
+    DELIVERY: {
+      inheritsBehaviorsFrom: 'ENGINEER',
+    },
+    COLLABORATION: {
+      inheritsBehaviorsFrom: 'ENGINEER',
+    },
+    STRATEGIC_CLARITY: {
+      inheritsBehaviorsFrom: 'ENGINEER',
+    },
+    LEADERSHIP: {
+      inheritsBehaviorsFrom: 'ENGINEER',
+    },
+  },
+  SENIOR_QA_ENGINEER: {
+    TECHNICAL_EXCELLENCE: {
+      behaviors: [
+        'Owns a service or large technology component.',
+        'Can solve large-sized problems with well designed and architected solutions.',
+        'Designs and implements testable solutions to problems. Consistently writes tests for new features and bug fixes. Adds tests for uncovered areas.',
+      ],
+    },
+    DELIVERY: {
+      inheritsBehaviorsFrom: 'SENIOR_ENGINEER',
+    },
+    COLLABORATION: {
+      inheritsBehaviorsFrom: 'SENIOR_ENGINEER',
+    },
+    STRATEGIC_CLARITY: {
+      inheritsBehaviorsFrom: 'SENIOR_ENGINEER',
+    },
+    LEADERSHIP: {
+      inheritsBehaviorsFrom: 'SENIOR_ENGINEER',
+    },
+  },
+  QA_AUTOMATION_ENGINEER: {
+    TECHNICAL_EXCELLENCE: {
+      behaviors: [
+        'Owns large-scale and impactful service or collection of services.',
+        'Mentors peers to avoid antipatterns.',
+        'Builds complex, reusable architectures that demonstrate best practices and enable engineers to work more effectively.',
+        'Actively educates their team on testing best practices. Builds systems so as to eliminate entire classes of programmer error.',
+      ],
+    },
+    DELIVERY: {
+      inheritsBehaviorsFrom: 'SENIOR_ENGINEER',
+    },
+    COLLABORATION: {
+      inheritsBehaviorsFrom: 'SENIOR_ENGINEER',
+    },
+    STRATEGIC_CLARITY: {
+      inheritsBehaviorsFrom: 'SENIOR_ENGINEER',
+    },
+    LEADERSHIP: {
+      inheritsBehaviorsFrom: 'SENIOR_ENGINEER',
+    },
+  },
+  SENIOR_QA_AUTOMATION_ENGINEER: {
+    TECHNICAL_EXCELLENCE: {
+      behaviors: [
+        'Designs and builds complex, flexible architectures that demonstrates best practices and prepares for future needs.',
+        'Demonstrates organization-level expertise in a particular area or go-to person for solving problems in their domain expertise for all of engineering.',
+        'Actively educates their team in their areas of knowledge.',
+        'Designs systems and applications for testability and quality.  Marshals resources to improve testability and quality of systems and applications that need it.',
+      ],
+    },
+    DELIVERY: {
+      inheritsBehaviorsFrom: 'STAFF_ENGINEER',
+    },
+    COLLABORATION: {
+      inheritsBehaviorsFrom: 'STAFF_ENGINEER',
+    },
+    STRATEGIC_CLARITY: {
+      inheritsBehaviorsFrom: 'STAFF_ENGINEER',
+    },
+    LEADERSHIP: {
+      inheritsBehaviorsFrom: 'STAFF_ENGINEER',
+    },
+  },
+  STAFF_QA_AUTOMATION_ENGINEER: {
+    TECHNICAL_EXCELLENCE: {
+      behaviors: [
+        'Helps solve larger technical and architectural problems with the team when they need support.',
+        'Demonstrates solid understanding of entire system, understands the architecture, is able to contribute across multiple technologies, and presents other technologies to leverage.',
+        'Works directly with other organizations to help solve technical problems.',
+        'Holds entire team including Staff, Principal and Architects to technical expectations and agreements.',
+      ],
+    },
+    DELIVERY: {
+      inheritsBehaviorsFrom: 'SENIOR_STAFF_ENGINEER',
+    },
+    COLLABORATION: {
+      inheritsBehaviorsFrom: 'SENIOR_STAFF_ENGINEER',
+    },
+    STRATEGIC_CLARITY: {
+      inheritsBehaviorsFrom: 'SENIOR_STAFF_ENGINEER',
+    },
+    LEADERSHIP: {
+      inheritsBehaviorsFrom: 'SENIOR_STAFF_ENGINEER',
+    },
+  },
+  QA_MANAGER: {
+    TECHNICAL_EXCELLENCE: {
+      inheritsBehaviorsFrom: 'ENGINEERING_MANAGER',
+    },
+    DELIVERY: {
+      inheritsBehaviorsFrom: 'ENGINEERING_MANAGER',
+    },
+    COLLABORATION: {
+      inheritsBehaviorsFrom: 'ENGINEERING_MANAGER',
+    },
+    STRATEGIC_CLARITY: {
+      inheritsBehaviorsFrom: 'SENIOR_STAFF_ENGINEER',
+    },
+    LEADERSHIP: {
+      inheritsBehaviorsFrom: 'SENIOR_STAFF_ENGINEER',
+    },
+  },
+  QA_DIRECTOR: {
+    TECHNICAL_EXCELLENCE: {
+      inheritsBehaviorsFrom: 'ENGINEERING_DIRECTOR',
+    },
+    DELIVERY: {
+      inheritsBehaviorsFrom: 'ENGINEERING_DIRECTOR',
+    },
+    COLLABORATION: {
+      inheritsBehaviorsFrom: 'ENGINEERING_DIRECTOR',
+    },
+    STRATEGIC_CLARITY: {
+      inheritsBehaviorsFrom: 'PRINCIPAL_ENGINEER',
+    },
+    LEADERSHIP: {
+      inheritsBehaviorsFrom: 'PRINCIPAL_ENGINEER',
+    },
+  },
+};
+
+export default QA_ROLE_EXPECTATIONS;

--- a/data/qa-expectations.js
+++ b/data/qa-expectations.js
@@ -96,7 +96,6 @@ const QA_ROLE_EXPECTATIONS = {
         'Proficiently able to create automated test scripts for mobile and web clients.',
         'Proficiently able to configure and maintain automation test environments.',
         'Basic understanding of automation testing for service and back-end layers.',
-
       ],
     },
     DELIVERY: {
@@ -115,7 +114,10 @@ const QA_ROLE_EXPECTATIONS = {
   STAFF_QA_AUTOMATION_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Understanding of automation architecture',
+        'Adept in implementing automation architecture and overarching automation test strategy using various technologies.',
+        'Extensive knowledge in supporting continuous integration and automated build systems.',
+        'Adept knowledge in automation of complex platform layers (Client, API, Services, Back-end).',
+        'Very strong skills in analysis and visualization of test data.',
       ],
     },
     DELIVERY: {

--- a/data/qa-expectations.js
+++ b/data/qa-expectations.js
@@ -68,11 +68,11 @@ const QA_ROLE_EXPECTATIONS = {
   QA_AUTOMATION_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Basic understanding of an OPP language (Swift, Java, C#, Objective-C, etc…) and/or scripting language (python, javascript etc..)',
-        'Basic understanding on Automation Frameworks (Selenium, Cucumber Appium etc…)',
-        'Proficiently able to transcribe manual test cases to automated (Gherkin) test cases',
-        'Proficiently able to write automated test scripts from automation (Gherkin) test cases',
-        'Proficiently able to troubleshoot and fix broken test scripts',
+        'Basic understanding of an OPP language (Swift, Java, C#, Objective-C, etc…) and/or scripting language (python, javascript etc..).',
+        'Basic understanding on Automation Frameworks (Selenium, Cucumber Appium etc…).',
+        'Proficiently able to transcribe manual test cases to automated (Gherkin) test cases.',
+        'Proficiently able to write automated test scripts from automation (Gherkin) test cases.',
+        'Proficiently able to troubleshoot and fix broken test scripts.',
       ],
     },
     DELIVERY: {
@@ -91,12 +91,12 @@ const QA_ROLE_EXPECTATIONS = {
   SENIOR_QA_AUTOMATION_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Knowledge of an OOP language (Swift,Java, C#, Objective-C, etc…)',
-        'Knowledge of a scripting language (python, javascript etc..)',
-        'Understanding of SQL',
-        'Understanding of API testing tools',
-        'Understanding of Automation Frameworks (selenium, cucumber etc…)',
-        'Understanding of Gherkin',
+        'Demonstrated skill in an OPP language (Swift, Java, C#, Objective-C, etc…) and/or scripting language (Python, Javascript etc..).',
+        'Proficient working with Automation Frameworks (Selenium, Cucumber, Appium etc…).',
+        'Proficiently able to create automated test scripts for mobile and web clients.',
+        'Proficiently able to configure and maintain automation test environments.',
+        'Basic understanding of automation testing for service and back-end layers.',
+
       ],
     },
     DELIVERY: {

--- a/data/qa-expectations.js
+++ b/data/qa-expectations.js
@@ -48,7 +48,7 @@ const QA_ROLE_EXPECTATIONS = {
         'Assist  in architecting manual test suites and frameworks.',
         'Maintain and create new automation test cases.',
         'Able to test multiple clients (Android/iOS/web) and platform implementations.',
-        'Assist in managing test suites, team boards, and process documentation',
+        'Assist in managing test suites, team boards, and process documentation.',
       ],
     },
     DELIVERY: {

--- a/data/qa-expectations.js
+++ b/data/qa-expectations.js
@@ -24,10 +24,10 @@ const QA_ROLE_EXPECTATIONS = {
   QA_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Perform exploratory, functional, regression, integration and end-to-end testing.',
-        'Able run automated tests and troubleshoot failures.',
-        'Able to test mobile apps against different versions and environments.',
-        'Able to test Web on multi-browsers while using DevTools proficiently to troubleshoot errors.',
+        'Create and maintain documentation (Test Cases, Process docs, Test Plans).',
+        'Perform exploratory, functional, regression, integration and end-to-end testing across mobile and web clients.',
+        'Proficient in trouble shooting errors using various tools (Devtools, Charles etc..).',
+
       ],
     },
     DELIVERY: {

--- a/data/qa-expectations.js
+++ b/data/qa-expectations.js
@@ -27,7 +27,6 @@ const QA_ROLE_EXPECTATIONS = {
         'Create and maintain documentation (Test Cases, Process docs, Test Plans).',
         'Perform exploratory, functional, regression, integration and end-to-end testing across mobile and web clients.',
         'Proficient in trouble shooting errors using various tools (Devtools, Charles etc..).',
-
       ],
     },
     DELIVERY: {

--- a/data/qa-expectations.js
+++ b/data/qa-expectations.js
@@ -68,12 +68,11 @@ const QA_ROLE_EXPECTATIONS = {
   QA_AUTOMATION_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Knowledge of automation frameworks',
-        'Basic understanding of SQL',
-        'Basic understanding of API testing tools',
-        'Basic understanding of browser development tools (Chrome DevTools)',
-        'Basic understanding of mobile debugging tools (Charles)',
-        'Basic understanding of black-box, gray-box and white-box testing',
+        'Basic understanding of an OPP language (Swift, Java, C#, Objective-C, etc…) and/or scripting language (python, javascript etc..)',
+        'Basic understanding on Automation Frameworks (Selenium, Cucumber Appium etc…)',
+        'Proficiently able to transcribe manual test cases to automated (Gherkin) test cases',
+        'Proficiently able to write automated test scripts from automation (Gherkin) test cases',
+        'Proficiently able to troubleshoot and fix broken test scripts',
       ],
     },
     DELIVERY: {

--- a/data/qa-expectations.js
+++ b/data/qa-expectations.js
@@ -67,7 +67,7 @@ const QA_ROLE_EXPECTATIONS = {
   QA_AUTOMATION_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Basic understanding of an OPP language (Swift, Java, C#, Objective-C, etc…) and/or scripting language (python, javascript etc..).',
+        'Basic understanding of object oriented programming in a modern language.',
         'Basic understanding on Automation Frameworks (Selenium, Cucumber Appium etc…).',
         'Proficiently able to transcribe manual test cases to automated (Gherkin) test cases.',
         'Proficiently able to write automated test scripts from automation (Gherkin) test cases.',
@@ -90,7 +90,7 @@ const QA_ROLE_EXPECTATIONS = {
   SENIOR_QA_AUTOMATION_ENGINEER: {
     TECHNICAL_EXCELLENCE: {
       behaviors: [
-        'Demonstrated skill in an OPP language (Swift, Java, C#, Objective-C, etc…) and/or scripting language (Python, Javascript etc..).',
+        'Demonstrated skill in object oriented programming in a modern language.',
         'Proficient working with Automation Frameworks (Selenium, Cucumber, Appium etc…).',
         'Proficiently able to create automated test scripts for mobile and web clients.',
         'Proficiently able to configure and maintain automation test environments.',

--- a/data/qa-roles.js
+++ b/data/qa-roles.js
@@ -25,6 +25,6 @@ const QA_ROLES = {
   },
 };
 
-QA_ROLES.asArray = Object.keys(QA_ROLES).map(key => ({ ...QA_ROLES[key], key }));
+export const QA_ROLES_ARRAY = Object.keys(QA_ROLES).map(key => ({ ...QA_ROLES[key], key }));
 
 export default QA_ROLES;

--- a/data/qa-roles.js
+++ b/data/qa-roles.js
@@ -19,6 +19,10 @@ const QA_ROLES = {
     title: 'Senior QA Automation Engineer',
     description: 'A brief paragraph about what it means to be a Seniot QA Automation Engineer',
   },
+  STAFF_QA_AUTOMATION_ENGINEER: {
+    title: 'Staff QA Automation Engineer',
+    description: 'A brief paragraph about what it means to be a Staff QA Automation Engineer',
+  },
   QA_MANAGER: {
     title: 'QA Manager',
     description: 'A brief paragraph about what it means to be a QA Manager',
@@ -27,10 +31,8 @@ const QA_ROLES = {
     title: 'QA Director',
     description: 'A brief paragraph about what it means to be an QA Director',
   },
-  STAFF_QA_AUTOMATION_ENGINEER: {
-    title: 'Staff QA Automation Engineer',
-    description: 'A brief paragraph about what it means to be a Staff QA Automation Engineer',
-  },
 };
+
+QA_ROLES.asArray = Object.keys(QA_ROLES).map(key => ({ ...QA_ROLES[key], key }));
 
 export default QA_ROLES;

--- a/data/qa-roles.js
+++ b/data/qa-roles.js
@@ -1,0 +1,36 @@
+const QA_ROLES = {
+  ASSOCIATE_QA_ENGINEER: {
+    title: 'Associate QA Engineer',
+    description: 'A brief paragraph about what it means to be an Associate QA Engineer',
+  },
+  QA_ENGINEER: {
+    title: 'QA Engineer',
+    description: 'A brief paragraph about what it means to be a QA Engineer',
+  },
+  SENIOR_QA_ENGINEER: {
+    title: 'Senior QA Engineer',
+    description: 'A brief paragraph about what it means to be a Senior QA Engineer',
+  },
+  QA_AUTOMATION_ENGINEER: {
+    title: 'QA Automation Engineer',
+    description: 'A brief paragraph about what it means to be a QA Automation Engineer',
+  },
+  SENIOR_QA_AUTOMATION_ENGINEER: {
+    title: 'Senior QA Automation Engineer',
+    description: 'A brief paragraph about what it means to be a Seniot QA Automation Engineer',
+  },
+  QA_MANAGER: {
+    title: 'QA Manager',
+    description: 'A brief paragraph about what it means to be a QA Manager',
+  },
+  QA_DIRECTOR: {
+    title: 'QA Director',
+    description: 'A brief paragraph about what it means to be an QA Director',
+  },
+  STAFF_QA_AUTOMATION_ENGINEER: {
+    title: 'Staff QA Automation Engineer',
+    description: 'A brief paragraph about what it means to be a Staff QA Automation Engineer',
+  },
+};
+
+export default QA_ROLES;

--- a/data/qa-roles.js
+++ b/data/qa-roles.js
@@ -1,35 +1,27 @@
 const QA_ROLES = {
   ASSOCIATE_QA_ENGINEER: {
     title: 'Associate QA Engineer',
-    description: 'A brief paragraph about what it means to be an Associate QA Engineer',
   },
   QA_ENGINEER: {
     title: 'QA Engineer',
-    description: 'A brief paragraph about what it means to be a QA Engineer',
   },
   SENIOR_QA_ENGINEER: {
     title: 'Senior QA Engineer',
-    description: 'A brief paragraph about what it means to be a Senior QA Engineer',
   },
   QA_AUTOMATION_ENGINEER: {
     title: 'QA Automation Engineer',
-    description: 'A brief paragraph about what it means to be a QA Automation Engineer',
   },
   SENIOR_QA_AUTOMATION_ENGINEER: {
     title: 'Senior QA Automation Engineer',
-    description: 'A brief paragraph about what it means to be a Seniot QA Automation Engineer',
   },
   STAFF_QA_AUTOMATION_ENGINEER: {
     title: 'Staff QA Automation Engineer',
-    description: 'A brief paragraph about what it means to be a Staff QA Automation Engineer',
   },
   QA_MANAGER: {
     title: 'QA Manager',
-    description: 'A brief paragraph about what it means to be a QA Manager',
   },
   QA_DIRECTOR: {
     title: 'QA Director',
-    description: 'A brief paragraph about what it means to be an QA Director',
   },
 };
 

--- a/data/roles.js
+++ b/data/roles.js
@@ -25,6 +25,6 @@ const ROLES = {
   },
 };
 
-ROLES.asArray = Object.keys(ROLES).map(key => ({ ...ROLES[key], key }));
+export const ROLES_ARRAY = Object.keys(ROLES).map(key => ({ ...ROLES[key], key }));
 
 export default ROLES;

--- a/data/roles.js
+++ b/data/roles.js
@@ -1,35 +1,27 @@
 const ROLES = {
   ASSOCIATE_ENGINEER: {
     title: 'Associate Engineer',
-    description: 'A brief paragraph about what it means to be an Associate Engineer',
   },
   ENGINEER: {
     title: 'Engineer',
-    description: 'A brief paragraph about what it means to be an Engineer',
   },
   SENIOR_ENGINEER: {
     title: 'Senior Engineer',
-    description: 'A brief paragraph about what it means to be a Senior Engineer',
   },
   STAFF_ENGINEER: {
     title: 'Staff Engineer',
-    description: 'A brief paragraph about what it means to be a Staff Engineer',
   },
   SENIOR_STAFF_ENGINEER: {
     title: 'Senior Staff Engineer',
-    description: 'A brief paragraph about what it means to be a Senior Staff Engineer',
   },
   ENGINEERING_MANAGER: {
     title: 'Engineering Manager',
-    description: 'A brief paragraph about what it means to be an Engineering Manager',
   },
   PRINCIPAL_ENGINEER: {
     title: 'Principal Engineer',
-    description: 'A brief paragraph about what it means to be a Principal Engineer',
   },
   ENGINEERING_DIRECTOR: {
     title: 'Engineering Director',
-    description: 'A brief paragraph about what it means to be an Engineering Director',
   },
 };
 

--- a/data/roles.js
+++ b/data/roles.js
@@ -33,4 +33,6 @@ const ROLES = {
   },
 };
 
+ROLES.asArray = Object.keys(ROLES).map(key => ({ ...ROLES[key], key }));
+
 export default ROLES;

--- a/md/Introduction.mdx
+++ b/md/Introduction.mdx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 # Career Journeys
 At Gloo we believe that every person is on a journey of growth within their life. This journey is multi-faceted and spans every aspect of life.
 
@@ -28,3 +30,20 @@ The purpose of the career journey framework is to:
   (<a target="_blank" rel="noopener noreferrer" href="https://www.forbes.com/sites/workday/2018/08/24/career-sprints-using-agile-development-methods-to-foster-employee-development/#55aadfb355eb">inspired by Workday</a>).
 
 \* There may be special circumstances when a manager can recommend a role change outside of the standard cadence based on exceptional contribution.
+
+## Roles
+
+<div><Link href="/roles"><a>Engineer Roles</a></Link></div>
+<div><Link href="/qa-roles"><a>QA Roles</a></Link></div>
+
+### Titles and Progression
+Role titles are for you, your manager and the team to understand your expected responsibilities and to track your progress, but you are free to use anything sensible for your outward facing title (e.g. LinkedIn, resume, etc.).
+
+Determining when to progress from one role to the next is a discussion that should happen between you and your manager. As a general guide, performing a significant percentage of the responsibilities of the next role for 3-6 months* would indicate readiness to step into that role.
+
+\* To clarify, this does not mean you should expect to be promoted every 3-6 months.  Especially at higher levels, it could take several years to be able to perform a significant of responsibilities of the next role.
+
+\* Also, the general expectation is that reviews occur once per year so most promotions are expected to occur at that yearly mark.
+
+### Balancing
+When a manager believes their direct report is ready to progress to a new role, they are expected to present their recommendation to a group of their peers in management. The purpose of this process is to ensure fairness and consistency when it comes to progression.

--- a/md/QARolesOverview.mdx
+++ b/md/QARolesOverview.mdx
@@ -1,4 +1,4 @@
-import QA_ROLES from '../data/qa-roles';
+import { QA_ROLES_ARRAY } from '../data/qa-roles';
 import RoleList from '../components/RoleList';
 import QARolesDiagram from '../components/QARolesDiagram';
 
@@ -15,4 +15,4 @@ QA Roles begin with a shared **QA Engineer** track and then fork at later levels
 <QARolesDiagram />
 
 ## Role Expectations
-<RoleList roles={QA_ROLES.asArray} />
+<RoleList roles={QA_ROLES_ARRAY} />

--- a/md/QARolesOverview.mdx
+++ b/md/QARolesOverview.mdx
@@ -6,7 +6,7 @@ import QARolesDiagram from '../components/QARolesDiagram';
 
 QA Roles begin with a shared **QA Engineer** track and then fork at later levels to the **QA Automation Engineer** and **People Manager** tracks.
 
-**QA Engineers** are focused on delivering value by testing software as part of the Engineering team.
+**QA Engineers** are focused on delivering value by assuring quality of product and process throughout the product life cycle.
 
 **QA Automation Engineers** are individuals with technical expertise in testing automation, focused on continuous improvement of their technical skills, leading by example, and developing the automation team.
 

--- a/md/QARolesOverview.mdx
+++ b/md/QARolesOverview.mdx
@@ -1,3 +1,13 @@
 import QARolesDiagram from '../components/QARolesDiagram';
 
+# Roles and Responsibilities
+
+QA Roles begin with a shared **QA Engineer** track and then fork at later levels to the **QA Automation Engineer** and **People Manager** tracks.
+
+**QA Engineers** are focused on delivering value by testing software as part of the Engineering team.
+
+**QA Automation Engineers** are individuals with technical expertise in testing automation, focused on continuous improvement of their technical skills, leading by example, and developing the automation team.
+
+**People Managers** are individuals with QA and leadership expertise who are focused on leading and growing the QA team.
+
 <QARolesDiagram />

--- a/md/QARolesOverview.mdx
+++ b/md/QARolesOverview.mdx
@@ -1,3 +1,5 @@
+import QA_ROLES from '../data/qa-roles';
+import RoleList from '../components/RoleList';
 import QARolesDiagram from '../components/QARolesDiagram';
 
 # Roles and Responsibilities
@@ -11,3 +13,6 @@ QA Roles begin with a shared **QA Engineer** track and then fork at later levels
 **People Managers** are individuals with QA and leadership expertise who are focused on leading and growing the QA team.
 
 <QARolesDiagram />
+
+## Role Expectations
+<RoleList roles={QA_ROLES.asArray} />

--- a/md/QARolesOverview.mdx
+++ b/md/QARolesOverview.mdx
@@ -1,0 +1,3 @@
+import QARolesDiagram from '../components/QARolesDiagram';
+
+<QARolesDiagram />

--- a/md/RolesOverview.mdx
+++ b/md/RolesOverview.mdx
@@ -1,4 +1,4 @@
-import ROLES from '../data/roles';
+import { ROLES_ARRAY } from '../data/roles';
 import FunctionList from '../components/FunctionList';
 import RoleList from '../components/RoleList';
 import RolesDiagram from '../components/RolesDiagram';
@@ -16,7 +16,7 @@ Roles begin with a shared **Engineer** track and then fork at later levels to th
 <RolesDiagram />
 
 ## Role Expectations
-<RoleList roles={ROLES.asArray} />
+<RoleList roles={ROLES_ARRAY} />
 
 ## Functions
 Functions describe responsibilities that you may be expected to fulfill for a period of time.

--- a/md/RolesOverview.mdx
+++ b/md/RolesOverview.mdx
@@ -15,18 +15,6 @@ Roles begin with a shared **Engineer** track and then fork at later levels to th
 
 <RolesDiagram />
 
-## Titles and Progression
-Role titles are for you, your manager and the team to understand your expected responsibilities and to track your progress, but you are free to use anything sensible for your outward facing title (e.g. LinkedIn, resume, etc.).
-
-Determining when to progress from one role to the next is a discussion that should happen between you and your manager. As a general guide, performing a significant percentage of the responsibilities of the next role for 3-6 months* would indicate readiness to step into that role.
-
-\* To clarify, this does not mean you should expect to be promoted every 3-6 months.  Especially at higher levels, it could take several years to be able to perform a significant of responsibilities of the next role.
-
-\* Also, the general expectation is that reviews occur once per year so most promotions are expected to occur at that yearly mark.
-
-## Balancing
-When a manager believes their direct report is ready to progress to a new role, they are expected to present their recommendation to a group of their peers in management. The purpose of this process is to ensure fairness and consistency when it comes to progression.
-
 ## Role Expectations
 <RoleList roles={ROLES.asArray} />
 

--- a/md/RolesOverview.mdx
+++ b/md/RolesOverview.mdx
@@ -1,3 +1,4 @@
+import ROLES from '../data/roles';
 import FunctionList from '../components/FunctionList';
 import RoleList from '../components/RoleList';
 import RolesDiagram from '../components/RolesDiagram';
@@ -27,7 +28,7 @@ Determining when to progress from one role to the next is a discussion that shou
 When a manager believes their direct report is ready to progress to a new role, they are expected to present their recommendation to a group of their peers in management. The purpose of this process is to ensure fairness and consistency when it comes to progression.
 
 ## Role Expectations
-<RoleList />
+<RoleList roles={ROLES.asArray} />
 
 ## Functions
 Functions describe responsibilities that you may be expected to fulfill for a period of time.

--- a/md/SkillsOverview.mdx
+++ b/md/SkillsOverview.mdx
@@ -1,3 +1,5 @@
+import { ROLES_ARRAY } from '../data/roles';
+import { QA_ROLES_ARRAY } from '../data/qa-roles';
 import SkillCards from '../components/SkillCards';
 import SkillList from '../components/SkillList';
 
@@ -17,4 +19,9 @@ Below is a list of core characteristics that great teammates should demonstrate 
 **Growth:** You are committed to the growth of yourself and your teammates.
 
 ## Skill Expectations
-<SkillList />
+
+### Engineer Skills
+<SkillList roles={ROLES_ARRAY} />
+
+### QA Skills
+<SkillList roles={QA_ROLES_ARRAY} />

--- a/md/SkillsOverview.mdx
+++ b/md/SkillsOverview.mdx
@@ -18,10 +18,16 @@ Below is a list of core characteristics that great teammates should demonstrate 
 
 **Growth:** You are committed to the growth of yourself and your teammates.
 
-## Skill Expectations
+<div className="hidden-anchor-root">
+  <div id="engineers" className="hidden-anchor" />
+</div>
 
-### Engineer Skills
+## Engineer Skills
 <SkillList roles={ROLES_ARRAY} />
 
-### QA Skills
+<div className="hidden-anchor-root">
+  <div id="qa-engineers" className="hidden-anchor" />
+</div>
+
+## QA Engineer Skills
 <SkillList roles={QA_ROLES_ARRAY} />

--- a/pages/qa-roles.js
+++ b/pages/qa-roles.js
@@ -1,10 +1,12 @@
+import QA_ROLES from '../data/qa-roles';
 import QARolesOverview from '../md/QARolesOverview.mdx';
+import RoleNavigation from '../components/RoleNavigation';
 import SideNavLayout from '../components/SideNavLayout';
 
 const Roles = () => (
   <SideNavLayout>
     <SideNavLayout.Nav>
-      <div>QA Role Navigation</div>
+      <RoleNavigation roles={QA_ROLES.asArray} />
     </SideNavLayout.Nav>
     <SideNavLayout.Content>
       <QARolesOverview />

--- a/pages/qa-roles.js
+++ b/pages/qa-roles.js
@@ -1,4 +1,4 @@
-import QA_ROLES from '../data/qa-roles';
+import { QA_ROLES_ARRAY } from '../data/qa-roles';
 import QARolesOverview from '../md/QARolesOverview.mdx';
 import RoleNavigation from '../components/RoleNavigation';
 import SideNavLayout from '../components/SideNavLayout';
@@ -6,7 +6,7 @@ import SideNavLayout from '../components/SideNavLayout';
 const Roles = () => (
   <SideNavLayout>
     <SideNavLayout.Nav>
-      <RoleNavigation roles={QA_ROLES.asArray} />
+      <RoleNavigation roles={QA_ROLES_ARRAY} />
     </SideNavLayout.Nav>
     <SideNavLayout.Content>
       <QARolesOverview />

--- a/pages/qa-roles.js
+++ b/pages/qa-roles.js
@@ -1,3 +1,4 @@
+import QARolesOverview from '../md/QARolesOverview.mdx';
 import SideNavLayout from '../components/SideNavLayout';
 
 const Roles = () => (
@@ -6,7 +7,7 @@ const Roles = () => (
       <div>QA Role Navigation</div>
     </SideNavLayout.Nav>
     <SideNavLayout.Content>
-      <div>QA Roles go here</div>
+      <QARolesOverview />
     </SideNavLayout.Content>
   </SideNavLayout>
 );

--- a/pages/qa-roles.js
+++ b/pages/qa-roles.js
@@ -1,0 +1,14 @@
+import SideNavLayout from '../components/SideNavLayout';
+
+const Roles = () => (
+  <SideNavLayout>
+    <SideNavLayout.Nav>
+      <div>QA Role Navigation</div>
+    </SideNavLayout.Nav>
+    <SideNavLayout.Content>
+      <div>QA Roles go here</div>
+    </SideNavLayout.Content>
+  </SideNavLayout>
+);
+
+export default Roles;

--- a/pages/roles.js
+++ b/pages/roles.js
@@ -1,3 +1,4 @@
+import ROLES from '../data/roles';
 import RolesOverview from '../md/RolesOverview.mdx';
 import RoleNavigation from '../components/RoleNavigation';
 import SideNavLayout from '../components/SideNavLayout';
@@ -5,7 +6,7 @@ import SideNavLayout from '../components/SideNavLayout';
 const Roles = () => (
   <SideNavLayout>
     <SideNavLayout.Nav>
-      <RoleNavigation />
+      <RoleNavigation roles={ROLES.asArray} />
     </SideNavLayout.Nav>
     <SideNavLayout.Content>
       <RolesOverview />

--- a/pages/roles.js
+++ b/pages/roles.js
@@ -1,4 +1,4 @@
-import ROLES from '../data/roles';
+import { ROLES_ARRAY } from '../data/roles';
 import RolesOverview from '../md/RolesOverview.mdx';
 import RoleNavigation from '../components/RoleNavigation';
 import SideNavLayout from '../components/SideNavLayout';
@@ -6,7 +6,7 @@ import SideNavLayout from '../components/SideNavLayout';
 const Roles = () => (
   <SideNavLayout>
     <SideNavLayout.Nav>
-      <RoleNavigation roles={ROLES.asArray} />
+      <RoleNavigation roles={ROLES_ARRAY} />
     </SideNavLayout.Nav>
     <SideNavLayout.Content>
       <RolesOverview />

--- a/pages/skills.js
+++ b/pages/skills.js
@@ -1,7 +1,16 @@
 import SkillsOverview from '../md/SkillsOverview.mdx';
+import SideNavLayout from '../components/SideNavLayout';
+import SkillNavigation from '../components/SkillNavigation';
 
 const Skills = () => (
-  <SkillsOverview />
+  <SideNavLayout>
+    <SideNavLayout.Nav>
+      <SkillNavigation />
+    </SideNavLayout.Nav>
+    <SideNavLayout.Content>
+      <SkillsOverview />
+    </SideNavLayout.Content>
+  </SideNavLayout>
 );
 
 export default Skills;


### PR DESCRIPTION
We need to establish a separate section for QA roles.

- QA has 3 tracks (QA Engineer at earlier levels, then forks into People Management and Automation Engineer)
- QA roles mostly differ from other Engineer roles in the Technical Excellence skill, so Delivery, Collaboration, Strategic Clarity and Leadership inherit from those. We can differentiate these if we need to.

Latest: https://career-journeys-bhzcaalihm.now.sh/qa-roles/